### PR TITLE
Multiple gRPC connections; waiting for gRPC connection to be available

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" project-jdk-name="14" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/client-ng-java.iml
+++ b/client-ng-java.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />

--- a/src/main/java/com/wandb/client/WandbRun.java
+++ b/src/main/java/com/wandb/client/WandbRun.java
@@ -35,12 +35,18 @@ public class WandbRun {
         this.stub = InternalServiceGrpc.newBlockingStub(this.channel);
 
         // Initialize with config
+        long startTime = System.nanoTime();
         while (this.run == null) {
             try {
                 this.run = this.stub.runUpdate(builder.runBuilder.build()).getRun();
             } catch (Exception e) {
                 // server was  not yet up, wait a moment and try again
                 Thread.sleep(200);
+                long elapsedTime = System.nanoTime() - startTime;
+                if (elapsedTime > 10_000_000_000L) {
+                    System.err.println("Could not establish a connection to the gRPC server in 10 seconds. Aborting.");
+                    throw e;
+                }
             }
         }
         this.stepCounter = 0;


### PR DESCRIPTION
This PR contains two changes:

1. It allows multiple, concurrent WandB runs by starting the gRPC server with the port set to the `WandbRun`. Note that this will only work when the PR wandb/client#1677 is included in the WandB client that is installed.
2. The original code waited 1s for the connection to the gRPC server to be established. This could fail depending on the environment. I changed this into a loop that tries again in case of failure for a maximum time of 10 seconds and then fails.

I was able to have multiple concurrent evaluations running and having them log to WandB in Java as expected.